### PR TITLE
Fix naming inconsistencies preventing 'showIssue' to be found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "github-issues",
-  "version": "0.0.7",
+  "name": "github-issue-viewer",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-issues",
-      "version": "0.0.7",
+      "name": "github-issue-viewer",
+      "version": "0.0.13",
       "dependencies": {
         "@octokit/rest": "^19.0.13",
         "marked": "^15.0.7"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ async function getGitHubSession(): Promise<vscode.AuthenticationSession> {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    let disposable = vscode.commands.registerCommand('github-issues.showIssue', async () => {
+    let disposable = vscode.commands.registerCommand('github-issue-viewer.showIssue', async () => {
         try {
             const session = await getGitHubSession();
             if (!session?.accessToken) {
@@ -25,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
                     retry
                 );
                 if (result === retry) {
-                    await vscode.commands.executeCommand('github-issues.showIssue');
+                    await vscode.commands.executeCommand('github-issue-viewer.showIssue');
                 }
                 return;
             }
@@ -135,7 +135,7 @@ export function activate(context: vscode.ExtensionContext) {
                 } else if (error.status === 401) {
                     // Force new authentication session
                     await getGitHubSession();
-                    vscode.commands.executeCommand('github-issues.showIssue');
+                    vscode.commands.executeCommand('github-issue-viewer.showIssue');
                 } else {
                     vscode.window.showErrorMessage(`GitHub API Error: ${error.message}`);
                 }
@@ -147,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
                 retry
             );
             if (result === retry) {
-                await vscode.commands.executeCommand('github-issues.showIssue');
+                await vscode.commands.executeCommand('github-issue-viewer.showIssue');
             }
         }
     });


### PR DESCRIPTION
As mentioned in issue #1, `github-issues.showIssue` cannot be found because it is registered as `github-issue-viewer.showIssue` in `package.json`.

To avoid possible naming conflicts with Microsoft's “GitHub Pull Request and Issues” extension (they also use a “GitHub-Issues” prefix), I decided to make the name change in the `extension.ts` file to `github-issue-viewer.showIssue`. The function call then works with this modification.
