### PR TITLE
Fix issue list to only include issues from the current repository

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
             const [, owner, repo] = remoteUrlMatch;
 
             try {
-                const issues = await octokit.issues.list({
+                const issues = await octokit.issues.listForRepo({
                     owner,
                     repo,
                     filter: 'assigned', // Changed from 'assigned' to 'all' for testing


### PR DESCRIPTION
# Description:
This PR fixes an issue where the "Show GitHub Issue" command incorrectly retrieves all issues assigned to the user across all repositories instead of limiting the list to the current repository.

# Changes made:

Replaced octokit.issues.list() with octokit.issues.listForRepo(), ensuring that only issues from the repository in the current workspace are retrieved.

# Before Fix:
A users Issues from all repositories were shown.
Selecting an issue from another repository resulted in incorrect behavior or errors.
# Now:
Only issues from the current repository are listed.
Selecting an issue reliably opens the correct issue in the WebView.
# Fixes:
Closes #3

Let me know if any adjustments are needed! 