### PR TITLE
Resolve git dir via gitdir: redirect (worktrees, submodules)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ interface IssueQuickPickItem extends vscode.QuickPickItem {
 // Returns:
 //   gitDir    — where HEAD lives (per-worktree)
 //   commonDir — where config lives (shared across worktrees)
-async function resolveGitDirs(
+export async function resolveGitDirs(
     workspaceFolder: vscode.WorkspaceFolder
 ): Promise<{ gitDir: vscode.Uri; commonDir: vscode.Uri }> {
     const dotGit = vscode.Uri.joinPath(workspaceFolder.uri, '.git');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Buffer } from 'node:buffer';
+import * as path from 'path';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 
 import buildGithubTimeline from './lib/timeline';
@@ -9,6 +10,54 @@ import { components } from '@octokit/openapi-types';
 
 interface IssueQuickPickItem extends vscode.QuickPickItem {
     number: string;
+}
+
+// Resolves the git directories for a workspace, handling the `gitdir:` redirect
+// used by linked worktrees, submodules, and other custom layouts where `.git`
+// is a file pointing elsewhere instead of a directory.
+//
+// Returns:
+//   gitDir    — where HEAD lives (per-worktree)
+//   commonDir — where config lives (shared across worktrees)
+async function resolveGitDirs(
+    workspaceFolder: vscode.WorkspaceFolder
+): Promise<{ gitDir: vscode.Uri; commonDir: vscode.Uri }> {
+    const dotGit = vscode.Uri.joinPath(workspaceFolder.uri, '.git');
+    const stat = await vscode.workspace.fs.stat(dotGit);
+
+    let gitDir: vscode.Uri;
+    if (stat.type === vscode.FileType.Directory) {
+        gitDir = dotGit;
+    } else {
+        const contents = Buffer.from(await vscode.workspace.fs.readFile(dotGit)).toString('utf8');
+        const match = contents.match(/^gitdir:\s*(.+)$/m);
+        if (!match) {
+            throw new Error('.git file does not contain a gitdir: pointer');
+        }
+        const target = match[1].trim();
+        const resolved = path.isAbsolute(target)
+            ? target
+            : path.resolve(workspaceFolder.uri.fsPath, target);
+        gitDir = vscode.Uri.file(resolved);
+    }
+
+    let commonDir = gitDir;
+    try {
+        const commonDirFile = vscode.Uri.joinPath(gitDir, 'commondir');
+        const commonDirContents = Buffer.from(
+            await vscode.workspace.fs.readFile(commonDirFile)
+        )
+            .toString('utf8')
+            .trim();
+        const resolvedCommon = path.isAbsolute(commonDirContents)
+            ? commonDirContents
+            : path.resolve(gitDir.fsPath, commonDirContents);
+        commonDir = vscode.Uri.file(resolvedCommon);
+    } catch {
+        // No commondir file — gitDir is its own common dir.
+    }
+
+    return { gitDir, commonDir };
 }
 
 async function getGitHubSession(): Promise<vscode.AuthenticationSession> {
@@ -51,8 +100,9 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             // Get repository info from git config
+            const { commonDir } = await resolveGitDirs(workspaceFolder);
             const gitConfig = await vscode.workspace.fs.readFile(
-                vscode.Uri.joinPath(workspaceFolder.uri, '.git', 'config')
+                vscode.Uri.joinPath(commonDir, 'config')
             );
             const configText = Buffer.from(gitConfig).toString('utf8');
             const remoteUrlMatch = configText.match(/url = .*github\.com[:/](.*?)\/(.*?)\.git/);
@@ -377,9 +427,9 @@ export function parseBranchNameForIssueNumber(branchName: string): string | null
 
 export async function getCurrentBranchIssueNumber(workspaceFolder: vscode.WorkspaceFolder): Promise<string | null> {
     try {
-        // Read the current branch from .git/HEAD
+        const { gitDir } = await resolveGitDirs(workspaceFolder);
         const headFile = await vscode.workspace.fs.readFile(
-            vscode.Uri.joinPath(workspaceFolder.uri, '.git', 'HEAD')
+            vscode.Uri.joinPath(gitDir, 'HEAD')
         );
         const headContent = Buffer.from(headFile).toString('utf8').trim();
         

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,6 +1,9 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
-import { parseBranchNameForIssueNumber } from '../extension';
+import { parseBranchNameForIssueNumber, resolveGitDirs } from '../extension';
 import buildWebviewContents from '../lib/webview';
 
 function buildMinimalIssueResponse(): any {
@@ -23,6 +26,14 @@ function extractInlineScript(html: string): string {
         throw new Error('no <script> block found in webview HTML');
     }
     return match[1];
+}
+
+function makeWorkspaceFolder(fsPath: string): vscode.WorkspaceFolder {
+    return {
+        uri: vscode.Uri.file(fsPath),
+        name: path.basename(fsPath),
+        index: 0,
+    };
 }
 
 suite('Extension Test Suite', () => {
@@ -255,6 +266,84 @@ suite('Extension Test Suite', () => {
             assert.match(scriptBody, /message\.newComment\.user/);
             assert.match(scriptBody, /message\.newComment\.body_html/);
             assert.match(scriptBody, /message\.newComment\.body\b/);
+        });
+    });
+
+    suite('resolveGitDirs', () => {
+        let tmpRoot: string;
+
+        setup(() => {
+            tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ghi-resolve-'));
+        });
+
+        teardown(() => {
+            fs.rmSync(tmpRoot, { recursive: true, force: true });
+        });
+
+        test('returns .git directory unchanged when .git is a directory', async () => {
+            const workspace = path.join(tmpRoot, 'plain');
+            fs.mkdirSync(path.join(workspace, '.git'), { recursive: true });
+
+            const { gitDir, commonDir } = await resolveGitDirs(makeWorkspaceFolder(workspace));
+
+            assert.strictEqual(gitDir.fsPath, path.join(workspace, '.git'));
+            assert.strictEqual(commonDir.fsPath, path.join(workspace, '.git'));
+        });
+
+        test('follows absolute gitdir: pointer when .git is a file', async () => {
+            const workspace = path.join(tmpRoot, 'with-pointer');
+            const realGit = path.join(tmpRoot, 'real-git');
+            fs.mkdirSync(workspace, { recursive: true });
+            fs.mkdirSync(realGit, { recursive: true });
+            fs.writeFileSync(path.join(workspace, '.git'), `gitdir: ${realGit}\n`);
+
+            const { gitDir, commonDir } = await resolveGitDirs(makeWorkspaceFolder(workspace));
+
+            assert.strictEqual(gitDir.fsPath, realGit);
+            assert.strictEqual(commonDir.fsPath, realGit);
+        });
+
+        test('resolves relative gitdir: pointer against the workspace folder', async () => {
+            const workspace = path.join(tmpRoot, 'submodule-host', 'sub');
+            const realGit = path.join(tmpRoot, 'submodule-host', '.git', 'modules', 'sub');
+            fs.mkdirSync(workspace, { recursive: true });
+            fs.mkdirSync(realGit, { recursive: true });
+            fs.writeFileSync(path.join(workspace, '.git'), 'gitdir: ../.git/modules/sub\n');
+
+            const { gitDir, commonDir } = await resolveGitDirs(makeWorkspaceFolder(workspace));
+
+            assert.strictEqual(gitDir.fsPath, realGit);
+            assert.strictEqual(commonDir.fsPath, realGit);
+        });
+
+        test('honors commondir for linked worktrees', async () => {
+            const main = path.join(tmpRoot, 'main-repo');
+            const mainGit = path.join(main, '.git');
+            const worktreeGit = path.join(mainGit, 'worktrees', 'feature');
+            const workspace = path.join(tmpRoot, 'feature-wt');
+
+            fs.mkdirSync(mainGit, { recursive: true });
+            fs.mkdirSync(worktreeGit, { recursive: true });
+            fs.mkdirSync(workspace, { recursive: true });
+
+            fs.writeFileSync(path.join(workspace, '.git'), `gitdir: ${worktreeGit}\n`);
+            fs.writeFileSync(path.join(worktreeGit, 'commondir'), '../..\n');
+
+            const { gitDir, commonDir } = await resolveGitDirs(makeWorkspaceFolder(workspace));
+
+            assert.strictEqual(gitDir.fsPath, worktreeGit);
+            assert.strictEqual(commonDir.fsPath, mainGit);
+        });
+
+        test('throws when .git file is missing a gitdir: pointer', async () => {
+            const workspace = path.join(tmpRoot, 'malformed');
+            fs.mkdirSync(workspace, { recursive: true });
+            fs.writeFileSync(path.join(workspace, '.git'), 'this is not a gitdir pointer\n');
+
+            await assert.rejects(
+                resolveGitDirs(makeWorkspaceFolder(workspace)),
+                /gitdir:/
+            );
         });
     });
 


### PR DESCRIPTION
## Summary
- Resolve the workspace's git directory via the `gitdir:` redirect when `.git` is a file (linked worktrees, submodules, or any layout where `.git` points elsewhere). Previously the extension assumed `.git` was a directory and the read of `.git/config` failed with ENOENT, blocking startup before authentication could even run.
- Honor the `commondir` file so worktree `HEAD` is read from the worktree gitdir while `config` is read from the shared common dir.

## Details
Added `resolveGitDirs(workspaceFolder)` in `src/extension.ts`. It stats `.git`, and:
- If it's a directory, both `gitDir` and `commonDir` are `.git`.
- If it's a file, it parses the `gitdir: <path>` line; relative paths are resolved against the workspace folder.
- If a `commondir` file exists alongside the resolved gitdir, its target is used as the `commonDir`.

Both call sites now use this helper:
- repo lookup reads `commonDir/config`
- branch lookup reads `gitDir/HEAD`

## Test plan
- [ ] `npm run compile` passes
- [ ] `npm run lint` passes
- [ ] In a normal repo (`.git` is a directory), opening the extension still resolves owner/repo and current branch correctly
- [ ] Reproduce the reported case (a project where `.git` is a file containing `gitdir: <path>`) and confirm the extension now finds the GitHub repo and authenticates
- [ ] In a linked worktree (`git worktree add`), confirm the extension uses the worktree's `HEAD` (so the per-worktree branch is detected) but reads `config` from the shared common dir

Closes #9