### PR TITLE
Filter pull requests out of the issue list

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,14 +146,18 @@ export function activate(context: vscode.ExtensionContext) {
                         },
                     });
 
-                    if (issues.data.length === 0) {
-                        vscode.window.showInformationMessage('No issues found for this repository');
+                    // GitHub's REST API returns pull requests alongside issues from this endpoint;
+                    // PRs carry a `pull_request` field, real issues don't.
+                    const onlyIssues = issues.data.filter(item => !item.pull_request);
+
+                    if (onlyIssues.length === 0) {
+                        vscode.window.showInformationMessage('No open issues found for this repository');
                         return;
                     }
 
                     const quickPick = vscode.window.createQuickPick<IssueQuickPickItem>();
                     quickPick.items = [
-                        ...issues.data.map((issue): IssueQuickPickItem => ({
+                        ...onlyIssues.map((issue): IssueQuickPickItem => ({
                             label: `#${issue.number} ${issue.title}`,
                             detail: issue.body?.substring(0, 100) + (issue.body && issue.body.length > 100 ? '...' : ''),
                             number: issue.number.toString(),
@@ -169,7 +173,7 @@ export function activate(context: vscode.ExtensionContext) {
                         if (/^\d+$/.test(trimmedValue)) {
                             // User typed a number, filter issues and add direct selection option
                             const issueNum = parseInt(trimmedValue);
-                            const filteredIssues = issues.data.filter(issue => 
+                            const filteredIssues = onlyIssues.filter(issue =>
                                 issue.number.toString().includes(trimmedValue) ||
                                 issue.title.toLowerCase().includes(trimmedValue.toLowerCase())
                             );
@@ -185,7 +189,7 @@ export function activate(context: vscode.ExtensionContext) {
                             ];
                         } else if (trimmedValue.length > 0) {
                             // Filter by title/content
-                            const filteredIssues = issues.data.filter(issue => 
+                            const filteredIssues = onlyIssues.filter(issue =>
                                 issue.title.toLowerCase().includes(trimmedValue.toLowerCase()) ||
                                 issue.body?.toLowerCase().includes(trimmedValue.toLowerCase())
                             );
@@ -200,7 +204,7 @@ export function activate(context: vscode.ExtensionContext) {
                         } else {
                             // Reset to full list
                             quickPick.items = [
-                                ...issues.data.map((issue): IssueQuickPickItem => ({
+                                ...onlyIssues.map((issue): IssueQuickPickItem => ({
                                     label: `#${issue.number} ${issue.title}`,
                                     detail: issue.body?.substring(0, 100) + (issue.body && issue.body.length > 100 ? '...' : ''),
                                     number: issue.number.toString(),


### PR DESCRIPTION
## Summary
`octokit.issues.listForRepo` returns both issues AND pull requests (GitHub's REST API treats every PR as an issue). The extension wasn't filtering the response, which produced two visible bugs:

- A repo with zero open issues but at least one open PR showed the QuickPick populated with PRs instead of the "no open issues" notification.
- Even when real issues existed, PRs were interleaved into the picker, labeled as if they were issues.

## Fix
Filter the response on the `pull_request` field (present only on PRs, absent on real issues) once after the API call, and use the filtered list everywhere downstream:
- the empty-list check that decides whether to show the notification,
- the initial QuickPick item builder,
- both branches of the `onDidChangeValue` filter (numeric prefix + free-text search).

Notification text updated from "No issues found for this repository" to "No open issues found for this repository" to match the actual condition (`state` defaults to `open` on the API call).

## Test plan
- [ ] `npm run compile` / `npm run lint` / `npm test` all pass (46 tests passing locally)
- [ ] Open the extension in a repo with **zero open issues but at least one open PR** — confirm the notification fires and the QuickPick does not appear
- [ ] Open the extension in a repo with **a mix of open issues and PRs** — confirm only issues appear in the picker
- [ ] Type a partial title/number into the picker — confirm filtering still works and still excludes PRs